### PR TITLE
Update wrapper-mysql.php

### DIFF
--- a/src/wrapper-mysql.php
+++ b/src/wrapper-mysql.php
@@ -55,7 +55,7 @@ function is_myresource ($o, $onlyres = false) {
 if ( ! function_exists ('mysql_connect') ) {
 
     if ( ! extension_loaded ('mysqli') ) {
-        throw new Exception (E_ERROR, 'MySQL wrapper must need mysqli extension');
+        throw new Exception ('MySQL wrapper needs the mysqli extension', E_ERROR);
     }
 
     if ( ! function_exists ('___ini_get') ) {


### PR DESCRIPTION
The order or arguments in the exception constructor is wrong. This is only visible, when mysqli is not available, thus the author quite likely never saw this for the user misleading error message:
PHP Fatal error:  Uncaught TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, string given in Standard input code:2
Stack trace:
#0 Standard input code(2): Exception->__construct()
#1 {main}
  thrown in Standard input code on line 58